### PR TITLE
Only use .swift files as source files

### DIFF
--- a/CBDatabase.podspec
+++ b/CBDatabase.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '10.0'
   s.swift_version = '4.2'
-  s.source_files = 'CBDatabase/**/*'
+  s.source_files = 'CBDatabase/**/*.swift'
 
   s.dependency 'RxSwift', '~> 4.3.0'
   s.dependency 'RxCocoa', '~> 4.3.0'


### PR DESCRIPTION
Including the Info.plist (found in CBDatabase/Modules/Info.plist) as sources makes cocoapods thinks it needs to be compiled. This causes an error because it gets both copied & compile which errors on duplicate file update. This should fix & be a little safer anyways.

Normally source files are in a `Source/` directory also to help protect against this, but seemed like a bigger fix.