### PR TITLE
Add `idColumn` to DatabaseModelObject & fix entityName

### DIFF
--- a/CBDatabase/DB/Database.swift
+++ b/CBDatabase/DB/Database.swift
@@ -59,11 +59,12 @@ public final class Database {
             .perform(operation: .write) { context -> [T] in
                 // check if model exists in database
                 let ids = models.map { $0.id }
-                let predicate = NSPredicate(format: "id in %@", ids)
+                let idField = T.idColumnName
+                let predicate = NSPredicate(format: "%K in %@", idField, ids)
                 let managedObjectMap: [String: NSManagedObject] = try context
                     .fetch(entityName: T.entityName, predicate: predicate)
                     .reduce(into: [:]) { dict, managedObject in
-                        guard let id = managedObject.value(forKey: "id") as? String else { return }
+                        guard let id = managedObject.value(forKey: idField) as? String else { return }
                         dict[id] = managedObject
                     }
 

--- a/CBDatabase/Protocols/DatabaseModelObject.swift
+++ b/CBDatabase/Protocols/DatabaseModelObject.swift
@@ -12,11 +12,22 @@ import CoreData
 ///         - Add the entity's attributes as ivars.
 ///         - If the entity name differs from the name of the struct, be sure to override entityName.
 public protocol DatabaseModelObject: Codable, Hashable {
+    /// The entity name of the managed object. By default this returns the same name of the struct.
+    static var entityName: String { get }
+    
+    /// Column that uniquely represents this object in CoreData. Used to find the object for things like `addOrUpdate`.
+    /// Defaults to "id"
+    static var idColumnName: String { get }
+
+    /// Unique string that represents this object
     var id: String { get }
 }
 
 extension DatabaseModelObject {
-    /// The entity name of the managed object. By default this returns the same name of the struct.
+    static var idColumnName: String {
+        return "id"
+    }
+    
     static var entityName: String {
         return String(describing: Self.self)
     }
@@ -74,7 +85,7 @@ extension DatabaseModelObject {
     /// - Returns: A fetch request for an object with the given identifier.
     static func fetchRequest<T>(id: String) -> NSFetchRequest<T> {
         let fetchRequest: NSFetchRequest<T> = Self.fetchRequest()
-        fetchRequest.predicate = NSPredicate(format: "id == [c] %@", id)
+        fetchRequest.predicate = NSPredicate(format: "%K == [c] %@", Self.idColumnName, id)
         return fetchRequest
     }
 

--- a/DatabasesTests/TestDatabase.xcdatamodeld/v2.0.xcdatamodel/contents
+++ b/DatabasesTests/TestDatabase.xcdatamodeld/v2.0.xcdatamodel/contents
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14315.18" systemVersion="18A391" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14460.32" systemVersion="17G3025" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="AdvancedModelCoreData" representedClassName="AdvancedModelCoreData" syncable="YES" codeGenerationType="class">
+        <attribute name="customIdField" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
     <entity name="TestCurrency" representedClassName="." syncable="YES">
         <attribute name="code" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="id" optional="YES" attributeType="String" syncable="YES"/>
@@ -19,6 +22,7 @@
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
     </entity>
     <elements>
+        <element name="AdvancedModelCoreData" positionX="63" positionY="180" width="128" height="60"/>
         <element name="TestCurrency" positionX="63" positionY="144" width="128" height="90"/>
         <element name="TestWallet" positionX="63" positionY="171" width="128" height="90"/>
     </elements>


### PR DESCRIPTION
In consumer land all of our ID's are things like accountID or userID. Because we also use the same objects to deserialize JSON from the API that we save to CoreData our CoreData schema needs to match our JSON Schema since they both share the same decoder. 

So I wanted to make it so that the field used to uniquely identify a record is customizable (while still providing backwards compatibility to yall). I know this adds a little more confusing to this code so feel free to close and I will just keep running my fork for now.

Another option for us would be to always do:
```swift
init(from decoder: Decoder) throws {
  let nestedValuesContainer = try decoder.container(keyedBy: CodingKeys.self)
  id = decoder.decodeIfAvailable(.id) ?? decoder.decode(.userId)
  name = decoder.decode(.name)
  ... etc
}
```

But it would add a lot of extra boilerplate needing to CodingKeys every model. 

Finally we could also separate the model objects for deserializing JSON from those for CoreData, which seems like what yall have done in Wallet and has its own benefits. Right now I think Decodable & CodingKeys is enough of a barrier for us to separate the JSON model from the internal model so I would rather not go that route (and if needed to would just go the CodingKeys route).


Anyways I wanted to see how much code this would require in this library. We will probably try to use this fork for now (at least while I implement things) to simplify the transition process. Happy to let it bake in Consumer land or just be divergent until we can do a more thorough solution in Consumer land. It isn't much code so I think merging any changes yall make upstream shouldn't be much of a problem so I don't think we will be that divergent.

I believe this is everywhere that the "id" keypath is referred to. I also needed to add `entityName` to the protocol because otherwise the code will always call the extensions implementation (even if you override it in the class implementing DatabaseObjectModel):
```swift
protocol BaseProtocol {
    var id: String { get }
}

extension BaseProtocol {
    var entityName: String { return "BaseProtocol EntityName" }
    var id: String { return "BaseProtocol id" }
}

struct Thing: BaseProtocol {
    let entityName = "Thing EntityName"
    var id: String { return "Thing id" }
}

let a = Thing()
a.entityName // "Thing EntityName"
a.id // "Thing id"
let b: BaseProtocol = Thing()
b.entityName // "BaseProtocol EntityName"
b.id // "Thing id"
```