### PR TITLE
Fix destroy DB call

### DIFF
--- a/CBDatabase/DB/DatabaseStorage.swift
+++ b/CBDatabase/DB/DatabaseStorage.swift
@@ -69,12 +69,7 @@ final class DatabaseStorage {
         let storeWALFile = "\(storeFile)-wal"
 
         [storeFile, storeSHMFile, storeWALFile].forEach { filename in
-            guard
-                let fileURL = DatabaseStorage.docURL?.appendingPathComponent(filename),
-                FileManager.default.fileExists(atPath: fileURL.absoluteString)
-            else {
-                return
-            }
+            guard let fileURL = DatabaseStorage.docURL?.appendingPathComponent(filename) else { return }
 
             try? FileManager.default.removeItem(at: fileURL)
         }


### PR DESCRIPTION
Previously files were not correctly destroyed due to `fileExists` call failing when URL contains spaces in the path. The patch removes the check and just ignores any errors if file doesn't exist.