### PR TITLE
Fix mutli-read/single-write dispatch queue

### DIFF
--- a/CBDatabase/DB/DatabaseStorage.swift
+++ b/CBDatabase/DB/DatabaseStorage.swift
@@ -12,8 +12,9 @@ final class DatabaseStorage {
     private let storeName: String
     private let scheduler = ConcurrentDispatchQueueScheduler(qos: .userInitiated)
     private let multiReadSingleWriteQueue = DispatchQueue(
-        label: "com.wallet.databases.multiWriteSingleReadQueue",
-        qos: .userInitiated
+        label: "CBDatabase.DatabaseStorage.multiWriteSingleReadQueue",
+        qos: .userInitiated,
+        attributes: .concurrent
     )
 
     /// CoreData's managed object context


### PR DESCRIPTION
Currently the must-read/single-write dispatch queue is marked as `serial`. It should've been marked `concurrent`