### PR TITLE
 Add Database.reset() to allow clearing database 

### DIFF
--- a/CBDatabase/DB/Database.swift
+++ b/CBDatabase/DB/Database.swift
@@ -10,8 +10,8 @@ public final class Database {
     private let disposeBag = DisposeBag()
     private let storage: DatabaseStorage
 
-    public init(type: DatabaseStorageType = .sqlite(nil), modelURL: URL, storeName: String = "DataStore") {
-        storage = DatabaseStorage(storage: type, modelURL: modelURL, storeName: storeName)
+    public init(type: DatabaseStorageType = .sqlite(nil), modelURL: URL, storeName: String = "DataStore") throws {
+        storage = try DatabaseStorage(storage: type, modelURL: modelURL, storeName: storeName)
     }
 
     /// Adds a new model to the database.
@@ -105,7 +105,7 @@ public final class Database {
     public func update<T: DatabaseModelObject>(_ models: [T]) -> Single<[T]?> {
         return storage
             .perform(operation: .write) { context -> [T] in
-                return try models.compactMap { model in
+                try models.compactMap { model in
                     if let managedObject = try context.fetch(T.self, identifier: model.id) {
                         model.configure(with: managedObject)
                         return model
@@ -320,8 +320,13 @@ public final class Database {
             }
     }
 
-    /// Deletes local sqlite file
+    /// Delete sqlite file and mark it as destroyed. All subsequent read/write operations will fail with and exception.
     public func destroy() {
         storage.destroy()
+    }
+
+    /// Completely clear the database.
+    public func reset() throws {
+        try storage.reset()
     }
 }

--- a/CBDatabase/Errors/DatabaseError.swift
+++ b/CBDatabase/Errors/DatabaseError.swift
@@ -15,4 +15,10 @@ public enum DatabaseError: Error {
 
     /// Error thrown whenever an add/update/query operation is fired when DB is in `destroyed` state
     case databaseDestroyed
+
+    /// Thrown when managed object model cannot be created during DB setup
+    case unableToCreateManagedObjectModel
+
+    /// Thrown when database setup fails
+    case unableToSetupDatabase
 }


### PR DESCRIPTION
1.  Add Database.reset() to allow clearing database without marking it destroyed.
2. Throw exceptions instead `fatalError` in case a DB error out  during setup. This allows us to handle the error and not crash the app