### PR TITLE
Bump cb-core version and fix build

### DIFF
--- a/android/databases/build.gradle
+++ b/android/databases/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     )
 
     androidTestImplementation(
+        "androidx.test.ext:junit:${testVersions.androidXTestExtJUnit}",
         "androidx.test:core:${testVersions.androidXTestCore}",
         "androidx.test:runner:${testVersions.androidXTestRunner}",
     )

--- a/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/db/Database.kt
+++ b/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/db/Database.kt
@@ -18,7 +18,6 @@ import java.util.concurrent.ConcurrentHashMap
 
 class Database<T : RoomDatabaseProvider>() {
     private lateinit var provider: RoomDatabaseProvider
-    private val scheduler: Scheduler by lazy { Schedulers.io() }
 
     constructor(disk: DiskOptions<T>) : this() {
         val builder = Room.databaseBuilder(disk.context, disk.providerClazz, disk.dbName)
@@ -48,6 +47,11 @@ class Database<T : RoomDatabaseProvider>() {
      * Mapping of class to Observer. Exposed for inline functions below
      */
     val observers = ConcurrentHashMap<Class<*>, PublishSubject<*>>()
+
+    /**
+     * Io scheduler used by database.  Only public so that it can be used in inline functions
+     */
+    val scheduler: Scheduler by lazy { Schedulers.io() }
 
     /**
      * Adds a new model to the database.

--- a/android/gradle/dependencies.gradle
+++ b/android/gradle/dependencies.gradle
@@ -8,9 +8,10 @@ ext {
     ]
 
     testVersions = [
-        junit4            : "4.12",
-        androidXTestCore  : "1.1.0",
-        androidXTestRunner: "1.1.0"
+        junit4              : "4.12",
+        androidXTestCore    : "1.1.0",
+        androidXTestRunner  : "1.1.0",
+        androidXTestExtJUnit: "1.0.0",
     ]
 
     otherVersions = [


### PR DESCRIPTION
Downgrading to buildToolsVersion 28.3.0

Also fix build - `private val scheduler` was being used in an inline function.  It should be made public