### PR TITLE
Add safe destroy and reset functions

### DIFF
--- a/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/db/Database.kt
+++ b/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/db/Database.kt
@@ -52,10 +52,10 @@ class Database<T : RoomDatabaseProvider> private constructor() {
     ): Single<Optional<List<T>>> = storage
         .perform<T, Optional<List<T>>>(DatabaseOperation.WRITE) { dao ->
             dao.add(models)
-            models.forEach { storage.notifyObservers(it.toOptional()) }
 
             models.toOptional()
         }
+        .doAfterSuccess { models.forEach { storage.notifyObservers(it.toOptional()) } }
 
     /**
      * Adds a new model or update if an existing record is found.
@@ -81,10 +81,10 @@ class Database<T : RoomDatabaseProvider> private constructor() {
     ): Single<Optional<List<T>>> = storage
         .perform<T, Optional<List<T>>>(DatabaseOperation.WRITE) { dao ->
             dao.addOrUpdate(models)
-            models.forEach { storage.notifyObservers(it.toOptional()) }
 
             models.toOptional()
         }
+        .doAfterSuccess { models.forEach { storage.notifyObservers(it.toOptional()) } }
 
     /**
      * Updates the object in the data store.
@@ -112,10 +112,10 @@ class Database<T : RoomDatabaseProvider> private constructor() {
     ): Single<Optional<List<T>>> = storage
         .perform<T, Optional<List<T>>>(DatabaseOperation.WRITE) { dao ->
             dao.update(models)
-            models.forEach { storage.notifyObservers(it.toOptional()) }
 
             models.toOptional()
         }
+        .doAfterSuccess { models.forEach { storage.notifyObservers(it.toOptional()) } }
 
     /**
      * Fetches objects from the data store using given SQL

--- a/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/db/Database.kt
+++ b/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/db/Database.kt
@@ -1,59 +1,32 @@
 package com.coinbase.wallet.libraries.databases.db
 
-import androidx.room.Room
 import androidx.sqlite.db.SimpleSQLiteQuery
 import com.coinbase.wallet.core.extensions.Strings
 import com.coinbase.wallet.core.extensions.empty
 import com.coinbase.wallet.core.util.Optional
 import com.coinbase.wallet.core.util.toOptional
 import com.coinbase.wallet.libraries.databases.exceptions.DatabaseException
-import com.coinbase.wallet.libraries.databases.interfaces.DatabaseDaoInterface
 import com.coinbase.wallet.libraries.databases.interfaces.DatabaseModelObject
+import com.coinbase.wallet.libraries.databases.model.DatabaseOperation
 import com.coinbase.wallet.libraries.databases.model.DiskOptions
 import com.coinbase.wallet.libraries.databases.model.MemoryOptions
 import io.reactivex.Observable
-import io.reactivex.Scheduler
 import io.reactivex.Single
-import io.reactivex.schedulers.Schedulers
-import io.reactivex.subjects.PublishSubject
-import java.util.concurrent.ConcurrentHashMap
 
-class Database<T : RoomDatabaseProvider>() {
-    private lateinit var provider: RoomDatabaseProvider
+class Database<T : RoomDatabaseProvider> private constructor() {
+    /**
+     * Manages the data underlying storage. Exposed due to inline functions restriction
+     */
+    lateinit var storage: Storage<T>
+        private set
 
     constructor(disk: DiskOptions<T>) : this() {
-        val builder = Room.databaseBuilder(disk.context, disk.providerClazz, disk.dbName)
-
-        disk.migrations.forEach { builder.addMigrations(it) }
-
-        if (disk.destructiveFallback) {
-            builder.fallbackToDestructiveMigration()
-        }
-
-        provider = builder.build()
-        modelDaos = provider.modelMappings()
+        storage = Storage(disk)
     }
 
     constructor(memory: MemoryOptions<T>) : this() {
-        provider = Room.inMemoryDatabaseBuilder(memory.context, memory.providerClazz).build()
-        modelDaos = provider.modelMappings()
+        storage = Storage(memory)
     }
-
-    /**
-     * Mapping of database models to Dao. Exposed for inline functions below.
-     */
-    lateinit var modelDaos: Map<Class<*>, DatabaseDaoInterface<*>>
-        private set
-
-    /**
-     * Mapping of class to Observer. Exposed for inline functions below
-     */
-    val observers = ConcurrentHashMap<Class<*>, PublishSubject<*>>()
-
-    /**
-     * Io scheduler used by database.  Only public so that it can be used in inline functions
-     */
-    val scheduler: Scheduler by lazy { Schedulers.io() }
 
     /**
      * Adds a new model to the database.
@@ -62,9 +35,9 @@ class Database<T : RoomDatabaseProvider>() {
      *
      * @return A Single wrapping an optional model indicating whether the add succeeded.
      */
-    inline fun <reified T : DatabaseModelObject> add(model: T): Single<Optional<T>> {
-        return add(listOf(model)).map { it.toNullable()?.firstOrNull().toOptional() }
-    }
+    inline fun <reified T : DatabaseModelObject> add(
+        model: T
+    ): Single<Optional<T>> = add(listOf(model)).map { it.value?.firstOrNull().toOptional() }
 
     /**
      * Adds new models to the database.
@@ -74,18 +47,15 @@ class Database<T : RoomDatabaseProvider>() {
      * @return A Single wrapping an optional list of models indicating whether the add succeeded.
      */
     @Suppress("UNCHECKED_CAST")
-    inline fun <reified T : DatabaseModelObject> add(models: List<T>): Single<Optional<List<T>>> {
-        val dao = modelDaos[T::class.java] as? DatabaseDaoInterface<T>
-            ?: return Single.error(DatabaseException.MissingDao(T::class.java))
+    inline fun <reified T : DatabaseModelObject> add(
+        models: List<T>
+    ): Single<Optional<List<T>>> = storage
+        .perform<T, Optional<List<T>>>(DatabaseOperation.WRITE) { dao ->
+            dao.add(models)
+            models.forEach { storage.notifyObservers(it.toOptional()) }
 
-        return dao.add(models)
-            .subscribeOn(scheduler)
-            .toSingleDefault(models.toOptional())
-            .onErrorReturn { null.toOptional() }
-            .doAfterSuccess { records ->
-                records.toNullable()?.forEach { notifyObservers(it.toOptional()) }
-            }
-    }
+            models.toOptional()
+        }
 
     /**
      * Adds a new model or update if an existing record is found.
@@ -94,9 +64,9 @@ class Database<T : RoomDatabaseProvider>() {
      *
      * @return A Single wrapping an optional model indicating whether the add/update succeeded.
      */
-    inline fun <reified T : DatabaseModelObject> addOrUpdate(model: T): Single<Optional<T>> {
-        return addOrUpdate(listOf(model)).map { it.toNullable()?.firstOrNull().toOptional() }
-    }
+    inline fun <reified T : DatabaseModelObject> addOrUpdate(
+        model: T
+    ): Single<Optional<T>> = addOrUpdate(listOf(model)).map { it.value?.firstOrNull().toOptional() }
 
     /**
      * Adds new models or update if existing records are found.
@@ -106,18 +76,15 @@ class Database<T : RoomDatabaseProvider>() {
      * @return A Single wrapping an optional list of models indicating whether the add/update succeeded.
      */
     @Suppress("UNCHECKED_CAST")
-    inline fun <reified T : DatabaseModelObject> addOrUpdate(models: List<T>): Single<Optional<List<T>>> {
-        val dao = modelDaos[T::class.java] as? DatabaseDaoInterface<T>
-            ?: return Single.error(DatabaseException.MissingDao(T::class.java))
+    inline fun <reified T : DatabaseModelObject> addOrUpdate(
+        models: List<T>
+    ): Single<Optional<List<T>>> = storage
+        .perform<T, Optional<List<T>>>(DatabaseOperation.WRITE) { dao ->
+            dao.addOrUpdate(models)
+            models.forEach { storage.notifyObservers(it.toOptional()) }
 
-        return dao.addOrUpdate(models)
-            .subscribeOn(scheduler)
-            .toSingleDefault(models.toOptional())
-            .onErrorReturn { null.toOptional() }
-            .doAfterSuccess { records ->
-                records.toNullable()?.forEach { notifyObservers(it.toOptional()) }
-            }
-    }
+            models.toOptional()
+        }
 
     /**
      * Updates the object in the data store.
@@ -127,9 +94,9 @@ class Database<T : RoomDatabaseProvider>() {
      * @return A Single representing whether the update succeeded. Succeeds is false if the object is not already
      *     in the database.
      */
-    inline fun <reified T : DatabaseModelObject> update(model: T): Single<Optional<T>> {
-        return update(listOf(model)).map { it.toNullable()?.firstOrNull().toOptional() }
-    }
+    inline fun <reified T : DatabaseModelObject> update(
+        model: T
+    ): Single<Optional<T>> = update(listOf(model)).map { it.value?.firstOrNull().toOptional() }
 
     /**
      * Updates the objects in the datastore
@@ -140,18 +107,15 @@ class Database<T : RoomDatabaseProvider>() {
      *         in the database.
      */
     @Suppress("UNCHECKED_CAST")
-    inline fun <reified T : DatabaseModelObject> update(models: List<T>): Single<Optional<List<T>>> {
-        val dao = modelDaos[T::class.java] as? DatabaseDaoInterface<T>
-            ?: return Single.error(DatabaseException.MissingDao(T::class.java))
+    inline fun <reified T : DatabaseModelObject> update(
+        models: List<T>
+    ): Single<Optional<List<T>>> = storage
+        .perform<T, Optional<List<T>>>(DatabaseOperation.WRITE) { dao ->
+            dao.update(models)
+            models.forEach { storage.notifyObservers(it.toOptional()) }
 
-        return dao.update(models)
-            .subscribeOn(scheduler)
-            .toSingleDefault(models.toOptional())
-            .onErrorReturn { null.toOptional() }
-            .doAfterSuccess { records ->
-                records.toNullable()?.forEach { notifyObservers(it.toOptional()) }
-            }
-    }
+            models.toOptional()
+        }
 
     /**
      * Fetches objects from the data store using given SQL
@@ -162,20 +126,19 @@ class Database<T : RoomDatabaseProvider>() {
      * @return A Single wrapping the items returned by the fetch.
      */
     @Suppress("UNCHECKED_CAST")
-    inline fun <reified T : DatabaseModelObject> fetch(query: String, vararg args: Any): Single<List<T>> {
-        val dao = modelDaos[T::class.java] as? DatabaseDaoInterface<T>
-            ?: return Single.error(DatabaseException.MissingDao(T::class.java))
-
-        return buildSQLQuery(query, *args).let { (newQuery, newArgs) ->
-            val fetcher = if (newArgs.isEmpty()) {
-                dao.fetch(SimpleSQLiteQuery(newQuery))
-            } else {
-                dao.fetch(SimpleSQLiteQuery(newQuery, newArgs))
+    inline fun <reified T : DatabaseModelObject> fetch(
+        query: String,
+        vararg args: Any
+    ): Single<List<T>> = storage
+        .perform<T, List<T>>(DatabaseOperation.READ) { dao ->
+            buildSQLQuery(query, *args).let { (newQuery, newArgs) ->
+                if (newArgs.isEmpty()) {
+                    dao.fetch(SimpleSQLiteQuery(newQuery))
+                } else {
+                    dao.fetch(SimpleSQLiteQuery(newQuery, newArgs))
+                }
             }
-
-            fetcher.subscribeOn(scheduler)
         }
-    }
 
     /**
      * Fetches a single model from the data store using given SQL
@@ -186,9 +149,37 @@ class Database<T : RoomDatabaseProvider>() {
      * @return A Single wrapping the item returned by the fetch.
      */
     @Suppress("UNCHECKED_CAST")
-    inline fun <reified T : DatabaseModelObject> fetchOne(query: String, vararg args: Any): Single<Optional<T>> {
-        return this.fetch<T>(query, *args).map { it.firstOrNull().toOptional() }
-    }
+    inline fun <reified T : DatabaseModelObject> fetchOne(
+        query: String,
+        vararg args: Any
+    ): Single<Optional<T>> = fetch<T>(query, *args)
+        .map { records ->
+            if (records.count() > 1) {
+                throw DatabaseException.MultipleRowsFetched
+            }
+
+            records.firstOrNull().toOptional()
+        }
+
+    /**
+     * Deletes the object from the data store.
+     *
+     * @param model The identifier of the object to be deleted.
+     *
+     * @return A Single wrapping a boolean indicating whether the delete succeeded.
+     */
+    @Suppress("UNCHECKED_CAST")
+    inline fun <reified T : DatabaseModelObject> delete(
+        model: T
+    ): Single<Boolean> = storage
+        .perform<T, Boolean>(DatabaseOperation.WRITE) { dao ->
+            try {
+                dao.delete(model)
+                true
+            } catch (e: Throwable) {
+                false
+            }
+        }
 
     /**
      * Counts total stored objects for a given class
@@ -199,38 +190,7 @@ class Database<T : RoomDatabaseProvider>() {
      * @return A Single wrapping the total number of records found
      */
     @Suppress("UNCHECKED_CAST")
-    fun count(query: String, vararg args: Any): Single<Int> {
-        return Single
-            .create<Int> { emitter ->
-                val cursor = provider.query(SimpleSQLiteQuery(query, args))
-                if (cursor.count == 0) {
-                    emitter.onSuccess(0)
-                } else {
-                    cursor.moveToNext()
-                    emitter.onSuccess(cursor.getInt(0))
-                }
-            }
-            .subscribeOn(scheduler)
-    }
-
-    /**
-     * Deletes the object from the data store.
-     *
-     * @param model The identifier of the object to be deleted.
-     *
-     * @return A Single wrapping a boolean indicating whether the delete succeeded.
-     */
-    @Suppress("UNCHECKED_CAST")
-    inline fun <reified T : DatabaseModelObject> delete(model: T): Single<Boolean> {
-        val dao = modelDaos[T::class.java] as? DatabaseDaoInterface<T>
-            ?: return Single.error(DatabaseException.MissingDao(T::class.java))
-
-        return dao.delete(model)
-            .subscribeOn(scheduler)
-            .toSingleDefault(true)
-            .onErrorReturn { false }
-            .doAfterSuccess { notifyObservers(model.toOptional()) }
-    }
+    fun count(query: String, vararg args: Any): Single<Int> = storage.count(query, *args)
 
     /**
      * Observe for a given model type
@@ -240,21 +200,7 @@ class Database<T : RoomDatabaseProvider>() {
      * @return Single wrapping the updated model or an error is thrown
      */
     @Suppress("UNCHECKED_CAST")
-    inline fun <reified T : DatabaseModelObject> observe(clazz: Class<T>): Observable<T> {
-        val subject: PublishSubject<T> = synchronized(this) {
-            val existingSubject = observers[clazz] as? PublishSubject<T>
-            if (existingSubject != null) {
-                return@synchronized existingSubject
-            }
-
-            val subject = PublishSubject.create<T>()
-            observers[clazz] = subject
-
-            return@synchronized subject
-        }
-
-        return subject.hide()
-    }
+    inline fun <reified T : DatabaseModelObject> observe(clazz: Class<T>): Observable<T> = storage.observe(clazz)
 
     /**
      * Observe for a given model
@@ -264,32 +210,20 @@ class Database<T : RoomDatabaseProvider>() {
      *
      * @return Single wrapping the updated model or an error is thrown
      */
-    inline fun <reified T : DatabaseModelObject> observe(clazz: Class<T>, id: String): Observable<T> {
-        return observe(clazz).filter { it.id == id }
-    }
+    inline fun <reified T : DatabaseModelObject> observe(
+        clazz: Class<T>,
+        id: String
+    ): Observable<T> = observe(clazz).filter { it.id == id }
 
     /**
-     * Notifies the observers of any changes. This is exposed due to inline function visibility restriction
-     *
-     * @param record A db record published to observers
+     * Delete sqlite file and marks it as destroyed. All read/write operations will fail
      */
-    @Suppress("UNCHECKED_CAST")
-    inline fun <reified T : DatabaseModelObject> notifyObservers(record: Optional<T>) {
-        val element = record.toNullable() ?: return
+    fun destroy() = storage.destroy()
 
-        val subject: PublishSubject<T> = synchronized(this) {
-            var subject = observers[T::class.java] as? PublishSubject<T>
-
-            if (subject == null) {
-                subject = PublishSubject.create()
-                observers[T::class.java] = subject
-            }
-
-            return@synchronized subject
-        }
-
-        subject.onNext(element)
-    }
+    /**
+     * Delete the current database sqlite file.
+     */
+    fun reset() = storage.reset()
 
     @Suppress("UNCHECKED_CAST")
     fun buildSQLQuery(query: String, vararg args: Any): Pair<String, Array<*>> {

--- a/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/db/Database.kt
+++ b/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/db/Database.kt
@@ -15,9 +15,10 @@ import io.reactivex.Single
 
 class Database<T : RoomDatabaseProvider> private constructor() {
     /**
-     * Manages the data underlying storage. Exposed due to inline functions restriction
+     * Manages the data underlying storage.
      */
-    lateinit var storage: Storage<T>
+    @PublishedApi
+    internal lateinit var storage: Storage<T>
         private set
 
     constructor(disk: DiskOptions<T>) : this() {
@@ -225,8 +226,11 @@ class Database<T : RoomDatabaseProvider> private constructor() {
      */
     fun reset() = storage.reset()
 
+    // Private/Internal helpers
+
     @Suppress("UNCHECKED_CAST")
-    fun buildSQLQuery(query: String, vararg args: Any): Pair<String, Array<*>> {
+    @PublishedApi
+    internal fun buildSQLQuery(query: String, vararg args: Any): Pair<String, Array<*>> {
         if (args.isEmpty() || query.count { it == '?' } != args.size) return Pair(query, args)
 
         val flatArgs = mutableListOf<Any>()

--- a/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/db/Storage.kt
+++ b/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/db/Storage.kt
@@ -24,35 +24,36 @@ import kotlin.concurrent.write
 /**
  *  Room sqlitedb storage handler
  *
- *  @property modelDaos Mapping of database models to Dao. Exposed for inline functions below.
+ *  @property modelDaos Mapping of database models to Dao.
  */
-class Storage<P : RoomDatabaseProvider> private constructor() {
+@PublishedApi
+internal class Storage<P : RoomDatabaseProvider> private constructor() {
     private lateinit var options: StorageOptions
     private lateinit var provider: RoomDatabaseProvider
 
     /**
-     * Mapping of class to Observer. Exposed due to inline functions restriction
+     * Mapping of class to Observer.
      */
     val observers = ConcurrentHashMap<Class<*>, PublishSubject<*>>()
 
     /**
-     * Mapping of database models to Dao. Exposed due to inline functions restriction
+     * Mapping of database models to Dao.
      */
     lateinit var modelDaos: Map<Class<*>, DatabaseDaoInterface<*>>
         private set
 
     /**
-     * Read/Write lock for accessing the database. Exposed due to inline functions restriction
+     * Read/Write lock for accessing the database.
      */
     val multiReadSingleWriteLock = ReentrantReadWriteLock()
 
     /**
-     * Io scheduler used by database. Exposed due to inline functions restriction
+     * Io scheduler used by database.
      */
     val scheduler: Scheduler by lazy { Schedulers.io() }
 
     /**
-     * Determine whether db was destroyed.Exposed due to inline functions restriction
+     * Determine whether db was destroyed.
      */
     var isDestroyed = false
         private set
@@ -174,7 +175,7 @@ class Storage<P : RoomDatabaseProvider> private constructor() {
     }
 
     /**
-     * Notifies the observers of any changes. This is exposed due to inline function visibility restriction
+     * Notifies the observers of any changes.
      *
      * @param record A db record published to observers
      */

--- a/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/db/Storage.kt
+++ b/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/db/Storage.kt
@@ -194,7 +194,7 @@ class Storage<P : RoomDatabaseProvider> private constructor() {
     }
 
     /**
-     * Create or create subject for given class type
+     * Get or create subject for given class type
      *
      * @param clazz: Generic type for the subject
      */

--- a/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/db/Storage.kt
+++ b/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/db/Storage.kt
@@ -1,0 +1,242 @@
+package com.coinbase.wallet.libraries.databases.db
+
+import androidx.room.Room
+import androidx.sqlite.db.SimpleSQLiteQuery
+import com.coinbase.wallet.core.util.Optional
+import com.coinbase.wallet.libraries.databases.exceptions.DatabaseException
+import com.coinbase.wallet.libraries.databases.interfaces.DatabaseDaoInterface
+import com.coinbase.wallet.libraries.databases.interfaces.DatabaseModelObject
+import com.coinbase.wallet.libraries.databases.interfaces.StorageOptions
+import com.coinbase.wallet.libraries.databases.model.DatabaseOperation
+import com.coinbase.wallet.libraries.databases.model.DiskOptions
+import com.coinbase.wallet.libraries.databases.model.MemoryOptions
+import io.reactivex.Observable
+import io.reactivex.Scheduler
+import io.reactivex.Single
+import io.reactivex.schedulers.Schedulers
+import io.reactivex.subjects.PublishSubject
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.locks.Lock
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import kotlin.concurrent.read
+import kotlin.concurrent.write
+
+/**
+ *  Room sqlitedb storage handler
+ *
+ *  @property modelDaos Mapping of database models to Dao. Exposed for inline functions below.
+ */
+class Storage<P : RoomDatabaseProvider> private constructor() {
+    private lateinit var options: StorageOptions
+    private lateinit var provider: RoomDatabaseProvider
+
+    /**
+     * Mapping of class to Observer. Exposed due to inline functions restriction
+     */
+    val observers = ConcurrentHashMap<Class<*>, PublishSubject<*>>()
+
+    /**
+     * Mapping of database models to Dao. Exposed due to inline functions restriction
+     */
+    lateinit var modelDaos: Map<Class<*>, DatabaseDaoInterface<*>>
+        private set
+
+    /**
+     * Read/Write lock for accessing the database. Exposed due to inline functions restriction
+     */
+    val multiReadSingleWriteLock = ReentrantReadWriteLock()
+
+    /**
+     * Io scheduler used by database. Exposed due to inline functions restriction
+     */
+    val scheduler: Scheduler by lazy { Schedulers.io() }
+
+    /**
+     * Determine whether db was destroyed.Exposed due to inline functions restriction
+     */
+    var isDestroyed = false
+        private set
+
+    constructor(disk: DiskOptions<P>) : this() {
+        val builder = Room.databaseBuilder(disk.context, disk.providerClazz, disk.dbName)
+
+        disk.migrations.forEach { builder.addMigrations(it) }
+
+        if (disk.destructiveFallback) {
+            builder.fallbackToDestructiveMigration()
+        }
+
+        provider = builder.build()
+        modelDaos = provider.modelMappings()
+        options = disk
+    }
+
+    constructor(memory: MemoryOptions<P>) : this() {
+        provider = Room.inMemoryDatabaseBuilder(memory.context, memory.providerClazz).build()
+        modelDaos = provider.modelMappings()
+        options = memory
+    }
+
+    /**
+     * Perform database operation within the read/write lock
+     *
+     * @param operation Indicate the type of operation to execute
+     * @param work closure called when performing a database operation
+     *
+     * @return Single wrapping model(s) involved in the db operation
+     */
+    @Suppress("UNCHECKED_CAST")
+    inline fun <reified T, reified R> perform(
+        operation: DatabaseOperation,
+        crossinline work: (dao: DatabaseDaoInterface<T>) -> R
+    ): Single<R> = Single
+        .create<R> { emitter ->
+            val lock: Lock = when (operation) {
+                DatabaseOperation.READ -> multiReadSingleWriteLock.readLock()
+                DatabaseOperation.WRITE -> multiReadSingleWriteLock.writeLock()
+            }
+
+            val dao = modelDaos[T::class.java] as? DatabaseDaoInterface<T>
+                ?: return@create emitter.onError(DatabaseException.MissingDao(T::class.java))
+
+            lock.lock()
+
+            if (isDestroyed) {
+                lock.unlock()
+                return@create emitter.onError(DatabaseException.DatabaseDestroyed)
+            }
+
+            try {
+                val result = work(dao) as? R ?: throw IllegalArgumentException("Invalid result")
+                emitter.onSuccess(result)
+            } catch (err: Throwable) {
+                emitter.onError(err)
+            } finally {
+                lock.unlock()
+            }
+        }
+        .subscribeOn(scheduler)
+        .observeOn(scheduler)
+
+    /**
+     * Counts total stored objects for a given class
+     *
+     * @param query SQL query used to filter count
+     * @param args Argument passed to fill placeholders in the query above
+     *
+     * @return A Single wrapping the total number of records found
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun count(
+        query: String,
+        vararg args: Any
+    ): Single<Int> = Single
+        .create<Int> { emitter ->
+            multiReadSingleWriteLock.read {
+                if (isDestroyed) {
+                    return@read emitter.onError(DatabaseException.DatabaseDestroyed)
+                }
+
+                try {
+                    val cursor = provider.query(SimpleSQLiteQuery(query, args))
+                    val result = if (cursor.count == 0) {
+                        0
+                    } else {
+                        cursor.moveToNext()
+                        cursor.getInt(0)
+                    }
+
+                    emitter.onSuccess(result)
+                } catch (err: Throwable) {
+                    emitter.onError(err)
+                }
+            }
+        }
+        .subscribeOn(scheduler)
+        .observeOn(scheduler)
+
+    /**
+     * Observe for a given model type
+     *
+     * @param clazz: Filter observer by model type
+     *
+     * @return Single wrapping the updated model or an error is thrown
+     */
+    @Suppress("UNCHECKED_CAST")
+    inline fun <reified T : DatabaseModelObject> observe(
+        clazz: Class<T>
+    ): Observable<T> = multiReadSingleWriteLock.read {
+        if (isDestroyed) {
+            return@read Observable.error(DatabaseException.DatabaseDestroyed)
+        }
+
+        synchronized(this) {
+            val existingSubject = observers[clazz] as? PublishSubject<T>
+            if (existingSubject != null) {
+                return@synchronized existingSubject.hide()
+            }
+
+            val subject = PublishSubject.create<T>()
+            observers[clazz] = subject
+
+            return@synchronized subject.hide()
+        }
+    }
+
+    /**
+     * Notifies the observers of any changes. This is exposed due to inline function visibility restriction
+     *
+     * @param record A db record published to observers
+     */
+    @Suppress("UNCHECKED_CAST")
+    inline fun <reified T : DatabaseModelObject> notifyObservers(record: Optional<T>) {
+        val element = record.toNullable() ?: return
+
+        val subject: PublishSubject<T> = synchronized(this) {
+            var subject = observers[T::class.java] as? PublishSubject<T>
+
+            if (subject == null) {
+                subject = PublishSubject.create()
+                observers[T::class.java] = subject
+            }
+
+            return@synchronized subject
+        }
+
+        subject.onNext(element)
+    }
+
+    /**
+     * Delete sqlite file and marks it as destroyed. All read/write operations will fail
+     */
+    fun destroy() = multiReadSingleWriteLock.write {
+        if (!isDestroyed) {
+            isDestroyed = true
+            reset()
+        }
+    }
+
+    /**
+     * Delete the current database sqlite file.
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun reset() = multiReadSingleWriteLock.write {
+        provider.beginTransaction()
+
+        try {
+            provider.clearAllTables()
+            provider.setTransactionSuccessful()
+        } finally {
+            provider.endTransaction()
+        }
+
+        (options as? DiskOptions<P>)?.let { disk ->
+            // Force a wal checkpoint which would transfer all transactions from the WAL file into the original DB.
+            // This step is just a precaution to make sure no data is left in the original DB file.
+            provider.query(SimpleSQLiteQuery("pragma wal_checkpoint(full)"))
+
+            // delete db files on file
+            disk.context.deleteDatabase(disk.dbName)
+        }
+    }
+}

--- a/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/exceptions/DatabaseException.kt
+++ b/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/exceptions/DatabaseException.kt
@@ -5,9 +5,19 @@ import java.lang.Exception
 /**
  * Represents exceptions thrown by module
  */
-class DatabaseException(val msg: String) : Exception(msg) {
+sealed class DatabaseException(msg: String) : Exception(msg) {
     /**
      * Thrown if unable to find DAO for provided model
      */
-    class MissingDao(clazz: Class<*>) : Exception("Unable to find DAO for $clazz")
+    class MissingDao(clazz: Class<*>) : DatabaseException("Unable to find DAO for $clazz")
+
+    /**
+     * Error thrown whenever an add/update/query operation is fired when DB is in `destroyed` state
+     */
+    object DatabaseDestroyed : DatabaseException("Database was destroyed")
+
+    /**
+     * Error thrown whenever fetchOne returns more than one row
+     */
+    object MultipleRowsFetched : DatabaseException("Mutliple rows fetched")
 }

--- a/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/interfaces/DatabaseDaoInterface.kt
+++ b/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/interfaces/DatabaseDaoInterface.kt
@@ -6,8 +6,6 @@ import androidx.room.Update
 import androidx.room.RawQuery
 import androidx.room.Delete
 import androidx.sqlite.db.SupportSQLiteQuery
-import io.reactivex.Completable
-import io.reactivex.Single
 
 /**
  * DAO interface used as a common DAO interface in Database object
@@ -21,7 +19,7 @@ interface DatabaseDaoInterface<T> {
      * @return A Completable indicating whether the operation completed
      */
     @Insert(onConflict = OnConflictStrategy.ABORT)
-    fun add(model: List<T>): Completable
+    fun add(model: List<T>)
 
     /**
      * Adds new models or update if existing records are found.
@@ -31,7 +29,7 @@ interface DatabaseDaoInterface<T> {
      * @return A Completable indicating whether the operation completed
      */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun addOrUpdate(model: List<T>): Completable
+    fun addOrUpdate(model: List<T>)
 
     /**
      * Updates the objects in the datastore
@@ -41,7 +39,7 @@ interface DatabaseDaoInterface<T> {
      * @return A Completable indicating whether the operation completed
      */
     @Update
-    fun update(model: List<T>): Completable
+    fun update(model: List<T>)
 
     /**
      * Fetches objects from the data store using given raw SQL
@@ -52,7 +50,7 @@ interface DatabaseDaoInterface<T> {
      * @return A Single wrapping the items returned by the fetch.
      */
     @RawQuery
-    fun fetch(query: SupportSQLiteQuery): Single<List<T>>
+    fun fetch(query: SupportSQLiteQuery): List<T>
 
     /**
      * Deletes the object from the data store.
@@ -62,5 +60,5 @@ interface DatabaseDaoInterface<T> {
      * @return A Completable indicating whether the operation completed
      */
     @Delete
-    fun delete(model: T): Completable
+    fun delete(model: T)
 }

--- a/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/interfaces/StorageOptions.kt
+++ b/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/interfaces/StorageOptions.kt
@@ -1,0 +1,6 @@
+package com.coinbase.wallet.libraries.databases.interfaces
+
+/**
+ * Implementers of this interface hold options (i.e. configurations) for the given implementer storage type
+ */
+interface StorageOptions

--- a/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/interfaces/StorageOptions.kt
+++ b/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/interfaces/StorageOptions.kt
@@ -3,4 +3,4 @@ package com.coinbase.wallet.libraries.databases.interfaces
 /**
  * Implementers of this interface hold options (i.e. configurations) for the given implementer storage type
  */
-interface StorageOptions
+internal interface StorageOptions

--- a/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/model/DatabaseOperation.kt
+++ b/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/model/DatabaseOperation.kt
@@ -1,0 +1,16 @@
+package com.coinbase.wallet.libraries.databases.model
+
+/**
+ * Represents a database operation
+ */
+enum class DatabaseOperation {
+    /**
+     * Read only operation
+     */
+    READ,
+
+    /**
+     * Write only operation
+     */
+    WRITE
+}

--- a/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/model/DatabaseOperation.kt
+++ b/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/model/DatabaseOperation.kt
@@ -3,7 +3,8 @@ package com.coinbase.wallet.libraries.databases.model
 /**
  * Represents a database operation
  */
-enum class DatabaseOperation {
+@PublishedApi
+internal enum class DatabaseOperation {
     /**
      * Read only operation
      */

--- a/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/model/DiskOptions.kt
+++ b/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/model/DiskOptions.kt
@@ -2,6 +2,7 @@ package com.coinbase.wallet.libraries.databases.model
 
 import android.content.Context
 import androidx.room.migration.Migration
+import com.coinbase.wallet.libraries.databases.interfaces.StorageOptions
 
 /**
  * Options for Room sqlite database
@@ -18,4 +19,4 @@ data class DiskOptions<T>(
     val dbName: String,
     val migrations: List<Migration> = emptyList(),
     val destructiveFallback: Boolean = false
-)
+) : StorageOptions

--- a/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/model/MemoryOptions.kt
+++ b/android/databases/src/main/java/com/coinbase/wallet/libraries/databases/model/MemoryOptions.kt
@@ -1,6 +1,7 @@
 package com.coinbase.wallet.libraries.databases.model
 
 import android.content.Context
+import com.coinbase.wallet.libraries.databases.interfaces.StorageOptions
 
 /**
  * Options for Room memory db
@@ -8,4 +9,4 @@ import android.content.Context
  * @property context Android context used to create room db
  * @property providerClazz Room-specific database provider
  */
-data class MemoryOptions<T>(val context: Context, val providerClazz: Class<T>)
+data class MemoryOptions<T>(val context: Context, val providerClazz: Class<T>) : StorageOptions


### PR DESCRIPTION
Add destroy/reset functions to match iOS

destroy - blows away the database and renders the DB unusable

reset - blows away the database but keeps it usable
